### PR TITLE
issue where connection is already open

### DIFF
--- a/StoredProcedureEFCore/StoredProcBuilder.cs
+++ b/StoredProcedureEFCore/StoredProcBuilder.cs
@@ -205,12 +205,19 @@ namespace StoredProcedureEFCore
 
     private void OpenConnection()
     {
-      _cmd.Connection.Open();
+      if (_cmd.Connection.State == ConnectionState.Closed)
+      {
+        _cmd.Connection.Open();
+      }
     }
 
     private Task OpenConnectionAsync()
     {
-      return _cmd.Connection.OpenAsync();
+      if (_cmd.Connection.State == ConnectionState.Closed)
+      {
+        return _cmd.Connection.OpenAsync();
+      }
+      return Task.CompletedTask;
     }
 
     private T DefaultIfDBNull<T>(object o)


### PR DESCRIPTION
Hi @verdie-g 

Could you have a look and see whether this causes any problems on your side.
On my side I had exceptions thrown when the stored proc lib is used where a connection was already used before invoking the sp. Crashing with following error :

```
System.InvalidOperationException: The connection was not closed. The connection's current state is open.
   at System.Data.ProviderBase.DbConnectionInternal.TryOpenConnection(DbConnection outerConnection, DbConnectionFactory connectionFactory, TaskCompletionSource`1 retry, DbConnectionOptions userOptions)
   at System.Data.SqlClient.SqlConnection.TryOpen(TaskCompletionSource`1 retry)
   at System.Data.SqlClient.SqlConnection.Open()
   at StoredProcedureEFCore.StoredProcBuilder.OpenConnection() in C:\Git\gravitymain\StoredProcedureEFCore\StoredProcBuilder.cs:line 214
   at StoredProcedureEFCore.StoredProcBuilder.Exec(Action`1 action) in C:\Git\gravitymain\StoredProcedureEFCore\StoredProcBuilder.cs:line 87
```

Thanks a lot for this lib. It may be because it is being used in a project mixed with EF.