### PR TITLE
Enable Db parameter support for Structured SP parameters

### DIFF
--- a/StoredProcedureEFCore/IStoredProcBuilder.cs
+++ b/StoredProcedureEFCore/IStoredProcBuilder.cs
@@ -59,12 +59,19 @@ namespace StoredProcedureEFCore
     IStoredProcBuilder AddParam<T>(string name, out IOutParam<T> outParam, ParamExtra extra);
 
     /// <summary>
+    /// Add pre configured DB query execution parameter directly command
+    /// </summary>
+    /// <param name="parameter">DB query execution parameter <see cref="DbParameter"/></param>
+    /// <returns></returns>
+    IStoredProcBuilder AddParam(DbParameter parameter);
+
+    /// <summary>
     /// Add return value parameter
     /// </summary>
     /// <typeparam name="T">Type of the parameter. Can be nullable</typeparam>
     /// <param name="retParam">Created parameter. Value will be populated after calling <see cref="Exec(Action{DbDataReader})"/></param>
     /// <returns></returns>
-    IStoredProcBuilder ReturnValue<T>(out IOutParam<T> retParam);
+        IStoredProcBuilder ReturnValue<T>(out IOutParam<T> retParam);
     
     /// <summary>
     /// Add return value parameter

--- a/StoredProcedureEFCore/IStoredProcBuilder.cs
+++ b/StoredProcedureEFCore/IStoredProcBuilder.cs
@@ -71,7 +71,7 @@ namespace StoredProcedureEFCore
     /// <typeparam name="T">Type of the parameter. Can be nullable</typeparam>
     /// <param name="retParam">Created parameter. Value will be populated after calling <see cref="Exec(Action{DbDataReader})"/></param>
     /// <returns></returns>
-        IStoredProcBuilder ReturnValue<T>(out IOutParam<T> retParam);
+    IStoredProcBuilder ReturnValue<T>(out IOutParam<T> retParam);
     
     /// <summary>
     /// Add return value parameter

--- a/StoredProcedureEFCore/StoredProcBuilder.cs
+++ b/StoredProcedureEFCore/StoredProcBuilder.cs
@@ -61,7 +61,7 @@ namespace StoredProcedureEFCore
 
     public IStoredProcBuilder AddParam(DbParameter parameter)
     {
-      if(parameter == null)
+      if (parameter == null)
       {
           throw new ArgumentNullException(nameof(parameter));
       }
@@ -81,7 +81,7 @@ namespace StoredProcedureEFCore
       retParam = AddOutputParamInner(_retParamName, default(T), ParameterDirection.ReturnValue, extra);
       return this;
     }
-    
+
     public IStoredProcBuilder SetTimeout(int timeout)
     {
       _cmd.CommandTimeout = timeout;

--- a/StoredProcedureEFCore/StoredProcBuilder.cs
+++ b/StoredProcedureEFCore/StoredProcBuilder.cs
@@ -59,6 +59,17 @@ namespace StoredProcedureEFCore
       return this;
     }
 
+    public IStoredProcBuilder AddParam(DbParameter parameter)
+    {
+      if(parameter == null)
+      {
+          throw new ArgumentNullException(nameof(parameter));
+      }
+
+      _cmd.Parameters.Add(parameter);
+      return this;
+    }
+
     public IStoredProcBuilder ReturnValue<T>(out IOutParam<T> retParam)
     {
       retParam = AddOutputParamInner(_retParamName, default(T), ParameterDirection.ReturnValue, null);
@@ -70,7 +81,7 @@ namespace StoredProcedureEFCore
       retParam = AddOutputParamInner(_retParamName, default(T), ParameterDirection.ReturnValue, extra);
       return this;
     }
-
+    
     public IStoredProcBuilder SetTimeout(int timeout)
     {
       _cmd.CommandTimeout = timeout;


### PR DESCRIPTION
Add AddParam method to IStoredProcedureBuilder that accepts DBParameter as entry. It is a possible option to allow to pass Structured parameters in.

resolve #8 