### PR TITLE
Allow null-Values for OUTPUT parameter

### DIFF
--- a/StoredProcedureEFCore.Tests.SqlServer.Database/StoredProcedureEFCore.Tests.SqlServer.Database.sqlproj
+++ b/StoredProcedureEFCore.Tests.SqlServer.Database/StoredProcedureEFCore.Tests.SqlServer.Database.sqlproj
@@ -71,6 +71,7 @@
     <Build Include="dbo\Stored Procedures\ListNotAll.sql" />
     <Build Include="dbo\Stored Procedures\SelectParam.sql" />
     <Build Include="dbo\Stored Procedures\OutputFixedSize.sql" />
+    <Build Include="dbo\Stored Procedures\OutputNullable.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="dbo\Scripts\Populate.sql" />

--- a/StoredProcedureEFCore.Tests.SqlServer.Database/dbo/Stored Procedures/OutputNullable.sql
+++ b/StoredProcedureEFCore.Tests.SqlServer.Database/dbo/Stored Procedures/OutputNullable.sql
@@ -1,0 +1,11 @@
+﻿-- =============================================
+-- Author:		Michael Kühberger
+-- Create date: 24/09/2019
+-- Description:
+-- =============================================
+CREATE PROCEDURE [dbo].[OutputNullable]
+  @nullable INT OUTPUT
+AS
+BEGIN
+	SET @nullable = null
+END

--- a/StoredProcedureEFCore.Tests.SqlServer/Program.cs
+++ b/StoredProcedureEFCore.Tests.SqlServer/Program.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.EntityFrameworkCore;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 
 namespace StoredProcedureEFCore.Tests.SqlServer
 {
@@ -61,6 +61,25 @@ namespace StoredProcedureEFCore.Tests.SqlServer
         .ExecNonQueryAsync();
 
       string s = fixedSizeParam.Value;
+
+      try
+      {
+        await ctx.LoadStoredProc("dbo.OutputNullable")
+          .AddParam("nullable", out IOutParam<int> nullableWithExceptionParameter)
+          .ExecNonQueryAsync();
+
+        var nullableWithException = nullableWithExceptionParameter.Value;
+      }
+      catch (InvalidOperationException)
+      {
+        // Should throw InvalidOperationException as int is not nullable
+      }
+
+      await ctx.LoadStoredProc("dbo.OutputNullable")
+          .AddParam("nullable", out IOutParam<int?> nullableParameter)
+          .ExecNonQueryAsync();
+
+      var nullable = nullableParameter.Value;
     }
   }
 }

--- a/StoredProcedureEFCore/OutputParameter.cs
+++ b/StoredProcedureEFCore/OutputParameter.cs
@@ -3,17 +3,31 @@ using System.Data.Common;
 
 namespace StoredProcedureEFCore
 {
-  internal class OutputParam<T> : IOutParam<T>
-  {
-    public OutputParam(DbParameter param)
+    internal class OutputParam<T> : IOutParam<T>
     {
-      _dbParam = param;
+        public OutputParam(DbParameter param)
+        {
+            _dbParam = param;
+        }
+
+        public T Value
+        {
+            get
+            {
+                if (_dbParam.Value is System.DBNull)
+                {
+                    if (Nullable.GetUnderlyingType(typeof(T)) != null)
+                    {
+                        return default(T);
+                    }
+                }
+
+                return (T)Convert.ChangeType(_dbParam.Value, typeof(T));
+            }
+        }
+
+        public override string ToString() => _dbParam.Value.ToString();
+
+        private DbParameter _dbParam;
     }
-
-    public T Value => (T)Convert.ChangeType(_dbParam.Value, typeof(T));
-
-    public override string ToString() => _dbParam.Value.ToString();
-
-    private DbParameter _dbParam;
-  }
 }

--- a/StoredProcedureEFCore/OutputParameter.cs
+++ b/StoredProcedureEFCore/OutputParameter.cs
@@ -3,31 +3,35 @@ using System.Data.Common;
 
 namespace StoredProcedureEFCore
 {
-    internal class OutputParam<T> : IOutParam<T>
+  internal class OutputParam<T> : IOutParam<T>
+  {
+    public OutputParam(DbParameter param)
     {
-        public OutputParam(DbParameter param)
-        {
-            _dbParam = param;
-        }
-
-        public T Value
-        {
-            get
-            {
-                if (_dbParam.Value is System.DBNull)
-                {
-                    if (Nullable.GetUnderlyingType(typeof(T)) != null)
-                    {
-                        return default(T);
-                    }
-                }
-
-                return (T)Convert.ChangeType(_dbParam.Value, typeof(T));
-            }
-        }
-
-        public override string ToString() => _dbParam.Value.ToString();
-
-        private DbParameter _dbParam;
+      _dbParam = param;
     }
+
+    public T Value
+    {
+      get
+      {
+        if (_dbParam.Value is DBNull)
+        {
+          if (default(T) == null)
+          {
+            return default(T);
+          }
+          else
+          {
+            throw new InvalidOperationException($"{_dbParam.ParameterName} is null and can't be assigned to a non-nullable type");
+          }
+        }
+
+        return (T)Convert.ChangeType(_dbParam.Value, typeof(T));
+      }
+    }
+
+    public override string ToString() => _dbParam.Value.ToString();
+
+    private DbParameter _dbParam;
+  }
 }


### PR DESCRIPTION
Currently it is not possible to run stored procedures with sets OUTPUT parameter to null. With this change it is possible if the given type allows null values.