### PR TITLE
Update StoredProcBuilder.cs

### DIFF
--- a/StoredProcedureEFCore/StoredProcBuilder.cs
+++ b/StoredProcedureEFCore/StoredProcBuilder.cs
@@ -12,7 +12,7 @@ namespace StoredProcedureEFCore
     {
         private const string RetParamName = "_retParam";
         private readonly DbCommand _cmd;
-
+        bool inTransaction = false;
         public StoredProcBuilder(DbContext ctx, string name)
         {
             if (name is null)
@@ -22,6 +22,7 @@ namespace StoredProcedureEFCore
             cmd.CommandType = CommandType.StoredProcedure;
             cmd.CommandText = name;
             cmd.Transaction = ctx.Database.CurrentTransaction?.GetDbTransaction();
+            inTransaction = ctx.Database.CurrentTransaction != null;
             cmd.CommandTimeout = ctx.Database.GetCommandTimeout().GetValueOrDefault(cmd.CommandTimeout);
 
             _cmd = cmd;
@@ -207,7 +208,8 @@ namespace StoredProcedureEFCore
 
         public void Dispose()
         {
-            _cmd.Connection.Close();
+            if (!inTransaction)
+                _cmd.Connection.Close();
             _cmd.Dispose();
         }
 

--- a/StoredProcedureEFCore/StoredProcBuilder.cs
+++ b/StoredProcedureEFCore/StoredProcBuilder.cs
@@ -225,7 +225,7 @@ namespace StoredProcedureEFCore
 
             DbParameter param = _cmd.CreateParameter();
             param.ParameterName = name;
-            param.Value = (object)val ?? DBNull.Value;
+            param.Value = (object) val ?? DBNull.Value;
             param.Direction = direction;
             param.DbType = DbTypeConverter.ConvertToDbType<T>();
             param.Size = size;
@@ -251,7 +251,7 @@ namespace StoredProcedureEFCore
 
         private static T DefaultIfDBNull<T>(object o)
         {
-            return o == DBNull.Value ? default(T) : (T)o;
+            return o == DBNull.Value ? default(T) : (T) o;
         }
     }
 }


### PR DESCRIPTION
Fixed committing a transaction when running a stored procedure. If there is currently an open transaction then when the SqlCommand finishes executing the connection stays open. If we close the connection then ADO.NET commits the transaction and no further changes can happen.

Issue described here #39 