### PR TITLE
Downgrade dependency of Microsoft.EntityFrameworkCore.Design

### DIFF
--- a/StoredProcedureEFCore/StoredProcedureEFCore.csproj
+++ b/StoredProcedureEFCore/StoredProcedureEFCore.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.0" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Hi!

We're happy to use your library and really like it!
We use the .net framework 2.2.0 (fixed) and your library in 0.3.10 which has a dependency to `Microsoft.EntityFrameworkCore.Design >= 1.0.1`.
You added a fix since this version regarding transactions and we're in urge to get this fix, but sadly you changed the dependency to `Microsoft.EntityFrameworkCore.Design >= 2.2.6`.
Is this update really required? Could you "downgrade" the requirement to `>= 2.2.0`?
We wan't to update the EF framework but it's impossible for the coming months. Downgrading the requirement wouldn't hurt your library anyway.

What's you opinion about that?